### PR TITLE
treewide: move to libiio 1.0i API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(ad9361 C)
 
 set(LIBAD9361_VERSION_MAJOR 0)
@@ -78,7 +78,7 @@ endif()
 add_definitions(-D_POSIX_C_SOURCE=200809L -D__XSI_VISIBLE=500 -DLIBAD9361_EXPORTS=1)
 
 find_library(LIBIIO_LIBRARIES iio)
-find_path(LIBIIO_INCLUDEDIR iio.h)
+find_path(LIBIIO_INCLUDEDIR iio/iio.h)
 
 set(LIBAD9361_HEADERS ad9361.h)
 

--- a/ad9361_baseband_auto_rate.c
+++ b/ad9361_baseband_auto_rate.c
@@ -15,7 +15,7 @@
 #include "ad9361.h"
 
 #include <errno.h>
-#include <iio.h>
+#include <iio/iio.h>
 #include <stdio.h>
 #ifdef _WIN32
 #include <windows.h>
@@ -146,7 +146,7 @@ int ad9361_set_bb_rate(struct iio_device *dev, unsigned long rate)
 		int dacrate, txrate, max;
 		char readbuf[100];
 
-		ret = iio_device_attr_read(dev, "tx_path_rates", readbuf, sizeof(readbuf));
+		ret = iio_device_attr_read_raw(dev, "tx_path_rates", readbuf, sizeof(readbuf));
 		if (ret < 0)
 			return ret;
 		ret = sscanf(readbuf, "BBPLL:%*d DAC:%d T2:%*d T1:%*d TF:%*d TXSAMP:%d", &dacrate, &txrate);

--- a/ad9361_design_taps.c
+++ b/ad9361_design_taps.c
@@ -15,7 +15,7 @@
 #include "ad9361.h"
 #include "filterdesigner/internal_design_filter_cg.h"
 #include <errno.h>
-#include <iio.h>
+#include <iio/iio.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -260,7 +260,7 @@ int apply_custom_filter(struct iio_device *dev, unsigned dec_tx,
 
         int dacrate, txrate, max;
         char readbuf[100];
-        ret = iio_device_attr_read(dev, "tx_path_rates", readbuf, sizeof(readbuf));
+        ret = iio_device_attr_read_raw(dev, "tx_path_rates", readbuf, sizeof(readbuf));
         if (ret < 0)
             return ret;
         ret = sscanf(readbuf, "BBPLL:%*d DAC:%d T2:%*d T1:%*d TF:%*d TXSAMP:%d",

--- a/ad9361_multichip_sync.c
+++ b/ad9361_multichip_sync.c
@@ -15,7 +15,7 @@
 #include "ad9361.h"
 
 #include <errno.h>
-#include <iio.h>
+#include <iio/iio.h>
 #include <stdio.h>
 #ifdef _WIN32
 #include <windows.h>
@@ -82,11 +82,11 @@ int ad9361_multichip_sync(struct iio_device *master, struct iio_device **slaves,
 	}
 
 	/* Move the parts int ALERT for MCS */
-	iio_device_attr_read(master, "ensm_mode", ensm_mode[0], sizeof(ensm_mode));
+	iio_device_attr_read_raw(master, "ensm_mode", ensm_mode[0], sizeof(ensm_mode));
 	iio_device_attr_write(master, "ensm_mode", "alert");
 
 	for (i = 0; i < num_slaves; i++) {
-		iio_device_attr_read(slaves[i], "ensm_mode", ensm_mode[i + 1], sizeof(ensm_mode));
+		iio_device_attr_read_raw(slaves[i], "ensm_mode", ensm_mode[i + 1], sizeof(ensm_mode));
 		iio_device_attr_write(slaves[i], "ensm_mode", "alert");
 	}
 

--- a/test/auto_rate_test_hw.c
+++ b/test/auto_rate_test_hw.c
@@ -8,11 +8,7 @@
 #include <string.h>
 #include <errno.h>
 
-#ifdef __APPLE__
 #include <iio/iio.h>
-#else
-#include <iio.h>
-#endif
 
 #define RATE_TOLERANCE_HZ 2
 
@@ -55,7 +51,7 @@ int main(void)
     const char* uri = getenv("URI_AD9361");
     if (uri == NULL)
         exit(0);// Cant find anything don't run tests
-    ctx = iio_create_context_from_uri(uri);
+    ctx = iio_create_context(NULL, uri);
     if (ctx == NULL) {
         printf("No device found... skipping test");
         exit(0);// Cant find anything don't run tests

--- a/test/filter_designer_hw.c
+++ b/test/filter_designer_hw.c
@@ -7,11 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef __APPLE__
 #include <iio/iio.h>
-#else
-#include <iio.h>
-#endif
 
 int main(void)
 {
@@ -25,7 +21,7 @@ int main(void)
     const char* uri = getenv("URI_AD9361");
     if (uri == NULL)
         exit(0);// Cant find anything don't run tests
-    ctx = iio_create_context_from_uri(uri);
+    ctx = iio_create_context(NULL, uri);
     if (ctx == NULL)
         exit(0);// Cant find anything don't run tests
     dev = iio_context_find_device(ctx, "ad9361-phy");

--- a/test/fmcomms5_sync_test.c
+++ b/test/fmcomms5_sync_test.c
@@ -3,11 +3,7 @@
 #include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
-#ifdef __APPLE__
 #include <iio/iio.h>
-#else
-#include <iio.h>
-#endif
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
@@ -51,6 +47,8 @@ static struct iio_device *dev_tx, *dev_tx_slave;
 static struct iio_buffer *rxbuf;
 static struct iio_channel *rxa_chan_real, *rxa_chan_imag;
 static struct iio_channel *rxb_chan_real, *rxb_chan_imag;
+static struct iio_channels_mask *dev_rx_mask;
+static struct iio_stream *dev_rx_stream;
 
 static void ad9361_sleep_ms(void)
 {
@@ -100,43 +98,54 @@ int streaming_interfaces(bool enable)
         if (!(rxa_chan_real && rxa_chan_imag && rxb_chan_real && rxb_chan_imag))
             streaming_interfaces(false);
 
-        iio_channel_enable(rxa_chan_real);
-        iio_channel_enable(rxa_chan_imag);
-        iio_channel_enable(rxb_chan_real);
-        iio_channel_enable(rxb_chan_imag);
-        rxbuf = iio_device_create_buffer(dev_rx, SAMPLES, false);
-        if (!rxbuf)
+        iio_channel_enable(rxa_chan_real, dev_rx_mask);
+        iio_channel_enable(rxa_chan_imag, dev_rx_mask);
+        iio_channel_enable(rxb_chan_real, dev_rx_mask);
+        iio_channel_enable(rxb_chan_imag, dev_rx_mask);
+        rxbuf = iio_device_create_buffer(dev_rx, 0, dev_rx_mask);
+        if (iio_err(rxbuf)) {
+            rxbuf = NULL;
             streaming_interfaces(false);
+        }
+        dev_rx_stream = iio_buffer_create_stream(rxbuf, 4, SAMPLES);
+        if (iio_err(dev_rx_stream)) {
+            dev_rx_stream = NULL;
+            streaming_interfaces(false);
+        }
     } else {
+        if (dev_rx_stream) {
+            iio_stream_destroy(dev_rx_stream);
+        }
         if (rxbuf) {
             iio_buffer_destroy(rxbuf);
         }
         if (rxa_chan_real) {
-            iio_channel_disable(rxa_chan_real);
+            iio_channel_disable(rxa_chan_real, dev_rx_mask);
         }
         if (rxa_chan_imag) {
-            iio_channel_disable(rxa_chan_imag);
+            iio_channel_disable(rxa_chan_imag, dev_rx_mask);
         }
         if (rxb_chan_real) {
-            iio_channel_disable(rxb_chan_real);
+            iio_channel_disable(rxb_chan_real, dev_rx_mask);
         }
         if (rxb_chan_imag) {
-            iio_channel_disable(rxb_chan_imag);
+            iio_channel_disable(rxb_chan_imag, dev_rx_mask);
         }
         return -1;
     }
     return 0;
 }
 
-void read_buffer_data(struct iio_channel *chn, struct iio_buffer *buf,
+void read_buffer_data(struct iio_channel *chn, const struct iio_block *block,
                       void *dst, size_t len)
 {
     uintptr_t src_ptr, dst_ptr = (uintptr_t)dst, end = dst_ptr + len;
     unsigned int bytes = iio_channel_get_data_format(chn)->length / 8;
-    uintptr_t buf_end = (uintptr_t)iio_buffer_end(buf);
-    ptrdiff_t buf_step = iio_buffer_step(buf);
+    uintptr_t buf_end = (uintptr_t)iio_block_end(block);
+    const struct iio_device *rx = iio_channel_get_device(chn);
+    ptrdiff_t buf_step = iio_device_get_sample_size(rx, dev_rx_mask);
 
-    for (src_ptr = (uintptr_t)iio_buffer_first(buf, chn);
+    for (src_ptr = (uintptr_t)iio_block_first(block, chn);
          src_ptr < buf_end && dst_ptr + bytes <= end;
          src_ptr += buf_step, dst_ptr += bytes)
         iio_channel_convert(chn, (void *)dst_ptr, (const void *)src_ptr);
@@ -144,18 +153,20 @@ void read_buffer_data(struct iio_channel *chn, struct iio_buffer *buf,
 
 double estimate_phase_diff(double *estimate)
 {
-    ssize_t nbytes_rx = iio_buffer_refill(rxbuf);
-    if (!nbytes_rx)
-        return nbytes_rx;
+    const struct iio_block *rxblock;
+
+    rxblock = iio_stream_get_next_block(dev_rx_stream);
+    if (iio_err(rxblock))
+        return iio_err(rxblock);
 
     int16_t myData0_i[SAMPLES], myData0_q[SAMPLES];
     int16_t myData2_i[SAMPLES], myData2_q[SAMPLES];
 
     // Read data from all channels
-    read_buffer_data(rxa_chan_real, rxbuf, myData0_i, SAMPLES * sizeof(int16_t));
-    read_buffer_data(rxa_chan_imag, rxbuf, myData0_q, SAMPLES * sizeof(int16_t));
-    read_buffer_data(rxb_chan_real, rxbuf, myData2_i, SAMPLES * sizeof(int16_t));
-    read_buffer_data(rxb_chan_imag, rxbuf, myData2_q, SAMPLES * sizeof(int16_t));
+    read_buffer_data(rxa_chan_real, rxblock, myData0_i, SAMPLES * sizeof(int16_t));
+    read_buffer_data(rxa_chan_imag, rxblock, myData0_q, SAMPLES * sizeof(int16_t));
+    read_buffer_data(rxb_chan_real, rxblock, myData2_i, SAMPLES * sizeof(int16_t));
+    read_buffer_data(rxb_chan_imag, rxblock, myData2_q, SAMPLES * sizeof(int16_t));
 
     ad9361_sleep_ms();
 
@@ -180,11 +191,18 @@ int setup_iio_devices(struct iio_context *ctx)
 
 int check_phase_sma(struct iio_context *ctx, double *est)
 {
+    unsigned int n_channels;
     int ret, g;
 
     // Set up devices
     if (!setup_iio_devices(ctx))
         return -ENODEV;
+
+    // Get device channel mask
+    n_channels = iio_device_get_channels_count(dev_rx);
+    dev_rx_mask = iio_create_channels_mask(n_channels);
+    if (!dev_rx_mask)
+        return -ENOMEM;
 
     // Enable channels
     if (streaming_interfaces(true) < 0)
@@ -196,6 +214,7 @@ int check_phase_sma(struct iio_context *ctx, double *est)
 
     // Disable channels
     streaming_interfaces(false);
+    iio_channels_mask_destroy(dev_rx_mask);
 
     return 0;
 }
@@ -207,7 +226,7 @@ int main(void)
     const char* uri = getenv("URI_FMCOMMS5");
     if (uri == NULL)
         exit(0);// Cant find anything don't run tests
-    ctx = iio_create_context_from_uri(uri);
+    ctx = iio_create_context(NULL, uri);
     if (ctx==NULL)
         exit(0);// Cant find anything don't run tests
     if (!check_fmcomms5_connected(ctx))


### PR DESCRIPTION
While at it, increased cmake minimum version to 3.10 as in other projects.